### PR TITLE
feat(common): Add flag to be able to set a relative yaw target [#21]

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2817,6 +2817,9 @@
       <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
         <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
       </entry>
+      <entry value="2" name="MAV_DO_REPOSITION_FLAGS_RELATIVE_YAW">
+        <description>The aircraft should set its yaw target relative to the current heading</description>
+      </entry>
     </enum>
     <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
     <enum name="ESTIMATOR_STATUS_FLAGS" bitmask="true">


### PR DESCRIPTION
## Description

This PR add the flag required for https://github.com/m4a3/aircraft-fcs/pull/196

is a flag bit in a bitmask to set the yaw target is relative rather an absolute

## Linked Issue

Use the following [guide](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to see how to link an issue

fixes #21 

## Reviewer checklist

*Developers should check these first*

- [ ] Branch has been rebased on to master branch
- [ ] No dead code
- [ ] Minimize nesting conditions
- [ ] Code is DRY (no duplicated code or functionality)
- [ ] Style guide adherence checked
- [ ] Spelling checked
- [ ] Milestone assigned
- [ ] Ensure issue is mentioned at the start of each commit message (To be automated in future)
- [ ] Changes documented in CHANGELOG

## Screenshots/Diagrams (if appropriate)

## Additional context

Add any other context or screenshots about the feature request here.
