### PR TITLE
feat(common): Add flag to be able to set a relative yaw target [#21]

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3191,6 +3191,9 @@
       <entry value="2048" name="POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE">
         <description>Ignore yaw rate</description>
       </entry>
+      <entry value="4096" name="POSITION_TARGET_TYPEMASK_RELATIVE_YAW">
+        <description>Interpret yaw relative to the vehicle current heading.</description>
+      </entry>
     </enum>
     <enum name="ATTITUDE_TARGET_TYPEMASK" bitmask="true">
       <description>Bitmap to indicate which dimensions should be ignored by the vehicle: a value of 0b00000000 indicates that none of the setpoint dimensions should be ignored.</description>


### PR DESCRIPTION
## Description

This add a flag to the POSITION_TARGET type mask to interpret yaw as relative to current heading.

## Linked Issue

Use the following [guide](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to see how to link an issue

fixes #21 

## Reviewer checklist

*Developers should check these first*

- [ ] Branch has been rebased on to master branch
- [ ] No dead code
- [ ] Minimize nesting conditions
- [ ] Code is DRY (no duplicated code or functionality)
- [ ] Style guide adherence checked
- [ ] Spelling checked
- [ ] Milestone assigned
- [ ] Ensure issue is mentioned at the start of each commit message (To be automated in future)
- [ ] Changes documented in CHANGELOG

## Screenshots/Diagrams (if appropriate)

## Additional context

Add any other context or screenshots about the feature request here.
